### PR TITLE
Proper fix for game-music-emu build when using gcc 10+

### DIFF
--- a/game-music-emu/CMakeLists.txt
+++ b/game-music-emu/CMakeLists.txt
@@ -84,7 +84,8 @@ if (CMAKE_COMPILER_IS_GNUCXX)
    if (__LIBGME_TEST_VISIBILITY)
       # get the gcc version
       exec_program(${CMAKE_CXX_COMPILER} ARGS --version OUTPUT_VARIABLE _gcc_version_info)
-      string (REGEX MATCH "[0-9]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
+      string (REGEX MATCH "[0-9]?[0-9]\\.[0-9]\\.[0-9]" _gcc_version "${_gcc_version_info}")
+      message("GCC Version: ${_gcc_version}")
 
       # gcc <4.1 had poor support for symbol visibility
       if ((${_gcc_version} VERSION_GREATER "4.1") OR (${_gcc_version} VERSION_EQUAL "4.1"))


### PR DESCRIPTION
Previous test would, for GCC version report version 10.x.x as 0.x.x, which would then fail the version checks. This change to the regex can now match versions of the form xx.x.x and x.x.x, so that 10.x.x can be correctly identified. The version is also printed as confirmation of this.